### PR TITLE
Fix of issue #75

### DIFF
--- a/src/dotnetplugins/Bari.Plugins.VsCore/cs/VisualStudio/ProjectSections/ReferencesSection.cs
+++ b/src/dotnetplugins/Bari.Plugins.VsCore/cs/VisualStudio/ProjectSections/ReferencesSection.cs
@@ -81,6 +81,7 @@ namespace Bari.Plugins.VsCore.VisualStudio.ProjectSections
                         writer.WriteAttributeString("Include", Path.GetFileNameWithoutExtension(relativePath));
                         writer.WriteElementString("HintPath", relativePath);
                         writer.WriteElementString("SpecificVersion", "False");
+                        writer.WriteElementString("Private", "True");
                     }
                     writer.WriteEndElement();
                 }


### PR DESCRIPTION
based on this SO question: http://stackoverflow.com/questions/1132243/msbuild-doesnt-copy-references-dlls-if-using-project-dependencies-in-solution
